### PR TITLE
Changed listed unity and CCK versions.

### DIFF
--- a/_variables/cck.json
+++ b/_variables/cck.json
@@ -1,36 +1,13 @@
 {
-  "cck23": {
-    "version": "v2.3 RELEASE",
-    "downloadUrl": "https://abi-static-web.abidata.io/ChilloutVR%20CCK%20v2.3%20RELEASE.unitypackage"
-  },
-  "cck30": {
-    "version": "v3.0 RELEASE",
-    "downloadUrl": "https://files.abidata.io/static_web/ChilloutVR%20CCK%20v3.0%20RELEASE.unitypackage"
-  },
   "cck": {
-    "version": "v3.2 RELEASE",
-    "downloadUrl": "https://files.abidata.io/static_web/ChilloutVR%20CCK%20v3.2%20RELEASE.unitypackage"
+    "version": "v3.7 RELEASE",
+    "downloadUrl": "https://files.abidata.io/static_web/ChilloutVR%20CCK%20v3.7%20RELEASE.unitypackage"
   },
   "unity": {
-    "install29": {
-      "version": "2019.4.29f1",
-      "hub": "unityhub://2019.4.29f1/0eeae20b1d82",
-      "executable": "https://download.unity3d.com/download_unity/0eeae20b1d82/UnityDownloadAssistant-2019.4.29f1.exe"
-    },
-    "install13": {
-      "version": "2019.4.13f1",
-      "hub": "unityhub://2019.4.13f1/518737b1de84",
-      "executable": "https://download.unity3d.com/download_unity/518737b1de84/UnityDownloadAssistant-2019.4.13f1.exe"
-    },
-    "install28": {
-      "version": "2019.4.28f1",
-      "hub": "unityhub://2019.4.28f1/1381962e9d08",
-      "executable": "https://download.unity3d.com/download_unity/1381962e9d08/UnityDownloadAssistant-2019.4.28f1.exe"
-    },
     "install": {
-      "version": "2019.4.31f1",
-      "hub": "unityhub://2019.4.31f1/bd5abf232a62",
-      "executable": "https://download.unity3d.com/download_unity/bd5abf232a62/UnityDownloadAssistant-2019.4.31f1.exe"
+      "version": "2021.3.23f1",
+      "hub": "unityhub://2021.3.23f1/213b516bf396",
+      "executable": "https://download.unity3d.com/download_unity/213b516bf396/UnityDownloadAssistant-2021.3.23f1.exe"
     }
   }
 }

--- a/_variables/chilloutvr.json
+++ b/_variables/chilloutvr.json
@@ -1,5 +1,5 @@
 {
   "unity": {
-    "nativeVersion": "2019.4.28f1"
+    "nativeVersion": "2021.3.23f1"
   }
 }

--- a/docs/cck/components/gi-material-updater.md
+++ b/docs/cck/components/gi-material-updater.md
@@ -1,10 +1,5 @@
 # CVR GI Material Updater
 
-!!! warning "Memory Leak"
-    Realtime Global Illumination has a massive memory leak in Unity 2019.4.
-    This was fixed in unity version 2019.4.30 and upwards. 
-    Consider not using, or enabling the component while the ChilloutVR is still on 2019.4.28.
-
 Calls `UpdateGIMaterials` on the same game objects [Renderer](https://docs.unity3d.com/ScriptReference/Renderer.html), there for requires some sort of [Renderer](https://docs.unity3d.com/ScriptReference/Renderer.html).
 
 This can be used to have realtime global illumination on emissive objects.

--- a/docs/cck/faq.md
+++ b/docs/cck/faq.md
@@ -8,15 +8,8 @@ You can find the most upto-date download link of our CCK here: [Setup Unity and 
 ChilloutVR is currently running on **Unity Version {{ chilloutvr.unity.nativeVersion }}**.  
 The CCK can be used with the following Unity Versions:
 
-+ **2019.3.1f1** (deprecated)
-+ **2019.4.13f1**
-+ **2019.4.28f1** (native)
-
-### Where can I find Guides?
-Our community already created some good guides for content creation.
-You can find them on our [Forum](https://forums.abinteractive.net/t/chilloutvr-tutorials).
++ **{{ cck.unity.install.version }}** (native)
 
 ### Still have more Questions?
 Couldn't find what you were looking for?  
-Check out our [Forums](https://forums.abinteractive.net/t/chilloutvr-content-creation) or join our
-[Discord]({{ abi.discord }}).
+Check out our [Discord]({{ abi.discord }})!


### PR DESCRIPTION
- Changed the listed Unity and CCK version to most recent (**Unity**: 2021.3.23f1 **CCK**: v3.7 RELEASE)
- Removed unused variables
- Removed a warning regarding a memory leak under the "CVR GI Material Editor" section from an older Unity version (2019.4.28)
- Removed references to the old defunct forums