### PR TITLE
Feature/initial wasm docs

### DIFF
--- a/docs/assets/stylesheets/extra.css
+++ b/docs/assets/stylesheets/extra.css
@@ -119,6 +119,12 @@ ARTICLES
 .md-typeset table:not([class]) {
     display: table;
 }
+/* Lets the docs stretch the full width of the screen. Needs tweaking on mobile... */
+/*.md-grid {
+    margin-left: 5rem;
+    margin-right: 5rem;
+    max-width: unset;
+}*/
 /* Zebra striping to make tables easier to read */
 [data-md-color-scheme="default"] .md-typeset__table thead tr,
 [data-md-color-scheme="default"] .md-typeset__table tbody tr:nth-child(even) {
@@ -129,9 +135,14 @@ ARTICLES
     background-color: color-mix(in srgb, white 5%, var(--md-default-bg-color, #1a1a1a));
 }
 /*Make all the table borders visible*/
-[data-md-color-scheme="default"] .md-typeset td:not([class]):not(:last-child) {
-    border: 0.05rem solid color-mix(in srgb, black 10%, var(--md-default-bg-color, #fff));
+table {
+    border-collapse: collapse;
 }
-[data-md-color-scheme="slate"] .md-typeset td:not([class]):not(:last-child) {
-    border: 0.05rem solid color-mix(in srgb, white 10%, var(--md-default-bg-color, #1a1a1a));
+[data-md-color-scheme="default"] table td,
+[data-md-color-scheme="default"] table th {
+    border: 1px solid color-mix(in srgb, black 10%, var(--md-default-bg-color, #1a1a1a));
+}
+[data-md-color-scheme="slate"] table td, 
+[data-md-color-scheme="slate"] table th {
+    border: 1px solid color-mix(in srgb, white 10%, var(--md-default-bg-color, #1a1a1a));
 }

--- a/docs/scripting/.pages
+++ b/docs/scripting/.pages
@@ -3,3 +3,4 @@ nav:
     - Getting Started: getting-started
     - API Reference: apis
     - Components: components
+    - Examples: examples

--- a/docs/scripting/apis/available-attributes.md
+++ b/docs/scripting/apis/available-attributes.md
@@ -36,11 +36,11 @@ This page lists some attributes available for scripting.
 The following attributes are not included in your built WASM module by default. 
 They can be included in your WASM module by adding `UNITY_EDITOR_ATTRIBUTES` to the `Scripting Define Symbols` in the [CCK Wasm Project Descriptor](../components/cck-wasm-project-descriptor.md) if you ever need to use them at runtime (not recommended).
 
-| Attribute                            | Description                                                   |
-|--------------------------------------|---------------------------------------------------------------|
-| [HideInInspector]                   | Hides a public field from the Unity Inspector.                |
-| [Header(string)]                    | Adds a header above a field in the Unity Inspector.           |
-| [PropertyRange(float min, float max)] | Constrains a numeric field to a range in the Unity Inspector. |
-| [Space(float height)]               | Adds vertical space above a field in the Unity Inspector.     |
-| [Tooltip(string)]                   | Adds a tooltip to a field in the Unity Inspector.             |
+| Attribute                              | Description                                                   |
+|----------------------------------------|---------------------------------------------------------------|
+| [HideInInspector]                      | Hides a public field from the Unity Inspector.                |
+| [Header(string)]                       | Adds a header above a field in the Unity Inspector.           |
+| [Range(float min, float max)]          | Constrains a numeric field to a range in the Unity Inspector. |
+| [Space(float height)]                  | Adds vertical space above a field in the Unity Inspector.     |
+| [Tooltip(string)]                      | Adds a tooltip to a field in the Unity Inspector.             |
 | [ColorUsage(bool showAlpha, bool hdr)] | Configures color field options in the Unity Inspector.        |

--- a/docs/scripting/apis/buffer-reader-writer.md
+++ b/docs/scripting/apis/buffer-reader-writer.md
@@ -1,4 +1,4 @@
-﻿<big><sub>**`WasmScripting`**</sub></big>
+﻿<big><sub>**`WasmScripting.BufferReaderWriter`**</sub></big>
 # BufferReaderWriter
 
 A helper for reading and writing data to byte buffers. Buffers grow automatically. Supports UTF8 and UTF16 strings.
@@ -11,15 +11,15 @@ A helper for reading and writing data to byte buffers. Buffers grow automaticall
 |----------------------------------------------|----------------------------------------------|
 | BufferReaderWriter(int initialCapacity = 64) | Creates a new buffer with the given capacity |
 | BufferReaderWriter(byte[] data)              | Wraps an existing byte array                 |
-| BufferReaderWriter(Span<byte> data)          | Wraps an existing span                       |
+| BufferReaderWriter(Span\&lt;byte\&lt; data)          | Wraps an existing span                       |
 
 ### Instance Properties
 
-| Signature         | Description                        |
-|-------------------|------------------------------------|
-| Span<byte> Buffer | The internal buffer                |
-| int Length        | Total number of bytes written      |
-| int Position      | Current read/write cursor position |
+| Signature           | Description                        |
+|---------------------|------------------------------------|
+| Span\&lt;byte\&lt; Buffer | The internal buffer                |
+| int Length          | Total number of bytes written      |
+| int Position        | Current read/write cursor position |
 
 ### Instance Methods
 
@@ -27,9 +27,9 @@ A helper for reading and writing data to byte buffers. Buffers grow automaticall
 
 | Signature                                                                         | Description                              |
 |-----------------------------------------------------------------------------------|------------------------------------------|
-| void Write<T>(T value) where T : unmanaged                                        | Writes a single value                    |
-| void Write<T>(T[] value, bool writeLength = true) where T : unmanaged             | Writes an array (optional length prefix) |
-| void Write<T>(ReadOnlySpan<T> value, bool writeLength = true) where T : unmanaged | Writes a span (optional length prefix)   |
+| void Write&lt;T&lt;(T value) where T : unmanaged                                        | Writes a single value                    |
+| void Write&lt;T&lt;(T[] value, bool writeLength = true) where T : unmanaged             | Writes an array (optional length prefix) |
+| void Write&lt;T&lt;(ReadOnlySpan&lt;T&lt; value, bool writeLength = true) where T : unmanaged | Writes a span (optional length prefix)   |
 | void Write(string value, Encoding encoding = null, bool writeLength = true)       | Writes a string (UTF8 by default)        |
 | void WriteStringFast(string value, bool writeLength = true)                       | Writes a UTF16 string                    |
 
@@ -37,44 +37,18 @@ A helper for reading and writing data to byte buffers. Buffers grow automaticall
 
 | Signature                                                       | Description                                      |
 |-----------------------------------------------------------------|--------------------------------------------------|
-| void Read<T>(out T value) where T : unmanaged                   | Reads a single value                             |
-| void Read<T>(out T[] value) where T : unmanaged                 | Reads an array (expects length prefix)           |
-| void Read<T>(out T[] value, int length) where T : unmanaged     | Reads an array of known length                   |
-| void Read<T>(out Span<T> value) where T : unmanaged             | Reads into a span (expects length prefix)        |
-| void Read<T>(out Span<T> value, int length) where T : unmanaged | Reads into a span of known length                |
+| void Read&lt;T&lt;(out T value) where T : unmanaged                   | Reads a single value                             |
+| void Read&lt;T&lt;(out T[] value) where T : unmanaged                 | Reads an array (expects length prefix)           |
+| void Read&lt;T&lt;(out T[] value, int length) where T : unmanaged     | Reads an array of known length                   |
+| void Read&lt;T&lt;(out Span&lt;T&lt; value) where T : unmanaged             | Reads into a span (expects length prefix)        |
+| void Read&lt;T&lt;(out Span&lt;T&lt; value, int length) where T : unmanaged | Reads into a span of known length                |
 | void Read(out string value, Encoding encoding = null)           | Reads a string (UTF8 by default, expects length) |
 | void Read(out string value, int size, Encoding encoding = null) | Reads a string of known size                     |
 | void ReadStringFast(out string value)                           | Reads a UTF16 string (expects length prefix)     |
 | void ReadStringFast(out string value, int length)               | Reads a UTF16 string of known length             |
 
-## Example
+## Relevant Examples
 
-```csharp
-public partial class BufferReaderWriterExample : WasmBehaviour
-{
-    private void Start()
-    {
-        // Write some values
-        BufferReaderWriter writer = new BufferReaderWriter();
-        writer.Write(12345);
-        writer.Write(3.14f);
-        writer.Write("Hello Buffer");
-        writer.Write(new int[] { 10, 20, 30 });
-
-        Debug.Log($"Wrote {writer.Length} bytes into buffer.");
-
-        // Read them back
-        BufferReaderWriter reader = new BufferReaderWriter(writer.Buffer[..writer.Length]);
-
-        reader.Read(out int intVal);
-        reader.Read(out float floatVal);
-        reader.Read(out string strVal);
-        reader.Read(out int[] arrayVal);
-
-        Debug.Log($"Int: {intVal}");
-        Debug.Log($"Float: {floatVal}");
-        Debug.Log($"String: {strVal}");
-        Debug.Log($"Array: [{string.Join(", ", arrayVal)}]");
-    }
-}
-```
+- [Buffer Reader Writer Usage](../examples/buffer-reader-writer-usage.md)
+- [Network Manager](../examples/network-manager.md)
+- [Writing A Text File](../examples/writing-a-text-file.md)

--- a/docs/scripting/apis/cvr-clone.md
+++ b/docs/scripting/apis/cvr-clone.md
@@ -11,7 +11,7 @@ Using this system you have full control over the clone's position, rotation, and
     Only **Worlds** may use the Clone API. Avatars and Props cannot use the Clone API due to it's expensive nature.
 
 ## CVRClone
-<big><sub>**`CVR.Clone`**</sub></big>
+<big><sub>**`CVR.CVRClone`**</sub></big>
 
 ### Static Members
 

--- a/docs/scripting/apis/cvr-layers.md
+++ b/docs/scripting/apis/cvr-layers.md
@@ -5,7 +5,7 @@
 Defines all CVR reserved and user-assignable layers used throughout CVR.
 This makes it easier to reference layers by name rather than hardcoding hard-to-remember integer values.
 
-## Layer Constants
+### Layer Constants
 
 | Name             | Value | Content Layer | Description                                                                           |
 |------------------|-------|---------------|---------------------------------------------------------------------------------------|

--- a/docs/scripting/apis/file-storage.md
+++ b/docs/scripting/apis/file-storage.md
@@ -26,8 +26,8 @@ Files are stored at: `/AppData/Local/ChilloutVR/LocalStorage/[WorldId]/[fileName
 |-----------------------------------------------------------------------|---------------------------------------|
 | [CVRFile](#CVRFile) ReadFile(string fileName)                         | Reads the entire file                 |
 | [CVRFile](#CVRFile) ReadFile(string fileName, int offset, int length) | Reads a segment of a file             |
-| void WriteFile(string fileName, Span&lt;byte&gt bytes)                     | Writes all bytes (overwrite)          |
-| void WriteFile(string fileName, Span&lt;byte&gt bytes, int offset)         | Writes bytes at a specific offset     |
+| void WriteFile(string fileName, Span&lt;byte&gt; bytes)               | Writes all bytes (overwrite)          |
+| void WriteFile(string fileName, Span&lt;byte&gt; bytes, int offset)   | Writes bytes at a specific offset     |
 | void DeleteFile(string fileName)                                      | Deletes a file                        |
 | void RenameFile(string oldFileName, string newFileName)               | Renames a file                        |
 | bool FileExists(string fileName)                                      | Checks if a file exists               |
@@ -36,7 +36,7 @@ Files are stored at: `/AppData/Local/ChilloutVR/LocalStorage/[WorldId]/[fileName
 | long GetTotalSize()                                                   | Total size of all stored files        |
 | long GetTotalCapacity()                                               | Maximum allowed storage size          |
 | bool CanUseFileStorage()                                              | Whether the world can use FileStorage |
-| void RequestUseFileStorage(Action<bool> onResult)                     | Prompts the user once for permission  |
+| void RequestUseFileStorage(Action&lt;bool&gt; onResult)               | Prompts the user once for permission  |
 
 ## CVRFile
 <small>**`WasmScripting.CVRFile`**</small>
@@ -45,10 +45,10 @@ Files are stored at: `/AppData/Local/ChilloutVR/LocalStorage/[WorldId]/[fileName
 
 ### Instance Properties
 
-| Member | Type       | Description                |
-|--------|------------|----------------------------|
-| Bytes  | Span&lt;byte&gt | The file's raw byte buffer |
-| Length | int        | Number of bytes returned   |
+| Member | Type             | Description                |
+|--------|------------------|----------------------------|
+| Bytes  | Span&lt;byte&gt; | The file's raw byte buffer |
+| Length | int              | Number of bytes returned   |
 
 `Bytes` is a live span referencing unmanaged memory.  
 Do **not** store it long-term; copy data if needed.

--- a/docs/scripting/apis/file-storage.md
+++ b/docs/scripting/apis/file-storage.md
@@ -11,7 +11,7 @@ Files are stored at: `/AppData/Local/ChilloutVR/LocalStorage/[WorldId]/[fileName
 ### Implementation Details
 
 * Worlds must request user permission to use FileStorage via `FileStorage.RequestUseFileStorage`.
-* Files written by this API are **sandboxed and encrypted**; scripts never see the real filesystem.
+* Files written by this API are **obfuscated**; scripts never see the real filesystem.
   * This is done to prevent writing malicious files, **not secure storage**. The encryption key is stored in the header of each written file.
 * Files added manually to a world's LocalStorage folder aren't counted against the world's storage, are read-only, and gated by a user permission.
 
@@ -26,8 +26,8 @@ Files are stored at: `/AppData/Local/ChilloutVR/LocalStorage/[WorldId]/[fileName
 |-----------------------------------------------------------------------|---------------------------------------|
 | [CVRFile](#CVRFile) ReadFile(string fileName)                         | Reads the entire file                 |
 | [CVRFile](#CVRFile) ReadFile(string fileName, int offset, int length) | Reads a segment of a file             |
-| void WriteFile(string fileName, Span<byte> bytes)                     | Writes all bytes (overwrite)          |
-| void WriteFile(string fileName, Span<byte> bytes, int offset)         | Writes bytes at a specific offset     |
+| void WriteFile(string fileName, Span&lt;byte&gt bytes)                     | Writes all bytes (overwrite)          |
+| void WriteFile(string fileName, Span&lt;byte&gt bytes, int offset)         | Writes bytes at a specific offset     |
 | void DeleteFile(string fileName)                                      | Deletes a file                        |
 | void RenameFile(string oldFileName, string newFileName)               | Renames a file                        |
 | bool FileExists(string fileName)                                      | Checks if a file exists               |
@@ -47,40 +47,12 @@ Files are stored at: `/AppData/Local/ChilloutVR/LocalStorage/[WorldId]/[fileName
 
 | Member | Type       | Description                |
 |--------|------------|----------------------------|
-| Bytes  | Span<byte> | The file's raw byte buffer |
+| Bytes  | Span&lt;byte&gt | The file's raw byte buffer |
 | Length | int        | Number of bytes returned   |
 
 `Bytes` is a live span referencing unmanaged memory.  
 Do **not** store it long-term; copy data if needed.
 
-## Example: Writing and Reading Files
+## Relevant Examples
 
-```csharp
-using UnityEngine;
-using WasmScripting;
-using CVR;
-
-public partial class FileStorageExample : WasmBehaviour
-{
-    void Start()
-    {
-        // Write file
-        string dataToWrite = "Hello, FileStorage!";
-        byte[] bytesToWrite = System.Text.Encoding.UTF8.GetBytes(dataToWrite);
-        FileStorage.WriteFile("test", bytesToWrite);
-
-        // Read file
-        CVRFile file = FileStorage.ReadFile("test");
-
-        if (file.Length > 0)
-        {
-            string content = System.Text.Encoding.UTF8.GetString(file.Bytes);
-            Debug.Log($"Read from FileStorage: {content}");
-        }
-        else
-        {
-            Debug.Log("No data found in FileStorage for 'test'");
-        }
-    }
-}
-```
+- [Writing A Text File](../examples/writing-a-text-file.md)

--- a/docs/scripting/apis/networking.md
+++ b/docs/scripting/apis/networking.md
@@ -1,68 +1,45 @@
-﻿<big><sub>**`WasmScripting`**</sub></big>
-# Networking API
+﻿# Networking API
 
 Provides low-level message sending and receiving. Currently uses Mod Network and has no concept of ownership.
 
 A proper high-level networking API is planned for a future update, built on top of this existing low-level API.
 
-## Static Members
+For networking-related events, see [Available Events - Networking Events](available-events.md/#networking-events).
 
-### Static Events
+## Networking
+<big><sub>**`WasmScripting.Networking`**</sub></big>
+
+### Static Members
+
+#### Static Events
 
 | Signature                                                | Description                            |
 |----------------------------------------------------------|----------------------------------------|
-| Action<[Player](player.md), Span<byte>> OnReceiveMessage | Invoked whenever a message is received |
+| Action<[Player](player.md), Span&lt;byte&gt; OnReceiveMessage | Invoked whenever a message is received |
 
-### Static Methods
+#### Static Methods
 
-| Signature                                                                                                                             | Description                                             |
-|---------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------|
-| void SendMessage(BufferReaderWriter writer, short[] playerIds = null, SendType sendType = SendType.Unreliable, bool loopback = false) | Sends a message using the given writer                  |
-| void SendMessage(Span<byte> message, short[] playerIds = null, SendType sendType = SendType.Unreliable, bool loopback = false)        | Sends a raw message                                     |
-| bool WillMessageBeDropped(int messageSize)                                                                                            | Returns true if a message of this size would be dropped |
-| float NetworkCloggedPercentage()                                                                                                      | Returns the network congestion percentage               |
-| int Ping                                                                                                                              | Current ping to the game server in ms                   |
-| [Player](player.md) GetInstanceOwner()                                                                                                | Returns the instance owner player                       |
+| Signature                                                                                                                                                                     | Description                                             |
+|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------|
+| void SendMessage([BufferReaderWriter](buffer-reader-writer.md) writer, short[] playerIds = null, [SendType](#sendtype) sendType = SendType.Unreliable, bool loopback = false) | Sends a message using the given writer                  |
+| void SendMessage(Span&lt;byte&gt; message, short[] playerIds = null, [SendType](#sendtype) sendType = SendType.Unreliable, bool loopback = false)                                          | Sends a raw message                                     |
+| bool WillMessageBeDropped(int messageSize)                                                                                                                                    | Returns true if a message of this size would be dropped |
+| float NetworkCloggedPercentage()                                                                                                                                              | Returns the network congestion percentage               |
+| int Ping                                                                                                                                                                      | Current ping to the game server in ms                   |
+| [Player](player.md) GetInstanceOwner()                                                                                                                                        | Returns the instance owner player                       |
 
-### Example
+!!! Tip
+    You can get player ids via the `NetworkId` property on the [Player API](player.md).
 
-```csharp
-using CVR;
-using WasmScripting;
+## SendType
+<big><sub>**`WasmScripting.SendType`**</sub></big>
 
-public partial class NetworkManager : WasmBehaviour
-{
+| Member              | Description                                     |
+|---------------------|-------------------------------------------------|
+| Unreliable          | Message may be dropped or arrive out of order   |
+| UnreliableSequenced | Message may be dropped but will arrive in order |
+| Reliable            | Message will arrive and in the order sent       |
 
-    private void Awake()
-    {
-        Networking.OnReceiveMessage += OnNetworkMessageReceived;
-    }
+## Relevant Examples
 
-    private enum MessageType : byte
-    {
-        ChatMessage = 0,
-    }
-
-    private void OnNetworkMessageReceived(Player sender, Span<byte> message)
-    {
-        BufferReaderWriter reader = new(message);
-        reader.Read(out MessageType type);
-
-        switch (type)
-        {
-            case MessageType.ChatMessage:
-                reader.Read(out string chatText);
-                TextWall.Instance.AddGlobalUserText(sender, chatText);
-                break;
-        }
-    }
-
-    public void SendTextChatMessage(string text)
-    {
-        BufferReaderWriter writer = new();
-        writer.Write(MessageType.ChatMessage);
-        writer.Write(text);
-        Networking.SendMessage(writer);
-    }
-}
-```
+- [Network Manager](../examples/network-manager.md)

--- a/docs/scripting/apis/portal.md
+++ b/docs/scripting/apis/portal.md
@@ -24,32 +24,6 @@ For portal-related events, see [Available Events - Portal Events](available-even
 | void SetPosition([Vector3](https://docs.unity3d.com/ScriptReference/Vector3.html) pos) | Sets the world position of portal    |
 | void SetRotation([Quaternion](https://docs.unity3d.com/ScriptReference/Quaternion.html) rot)                                                       | Sets the world rotation of portal    |
 
-## Example
+## Relevant Examples
 
-```csharp
-/// Simple script that keeps portals within 2 meters of the player that spawned them
-public partial class PortalFollower : WasmBehaviour
-{
-    private readonly List<Portal> _spawnedPortals = new();
-    
-    private void OnPortalCreated(Portal portal) => _spawnedPortals.Add(portal);
-    private void OnPortalDestroyed(Portal portal) => _spawnedPortals.Remove(portal);
-
-    private void Update()
-    {
-        foreach (Portal portal in _spawnedPortals)
-        {
-            Player dropper = portal?.Spawner;
-            if (dropper == null) continue;
-            
-            Vector3 portalPos = portal.GetPosition();
-            Vector3 dropperPos = dropper.GameObject.transform.position;
-            if (Vector3.Distance(portalPos, dropperPos) > 2f)
-            {
-                Vector3 direction = (portalPos - dropperPos).normalized;
-                portal.SetPosition(dropperPos + direction * 2f);
-            }
-        }
-    }
-}
-```
+- [Dropped Portals Follow Spawner](../examples/dropped-portals-follow-spawner.md)

--- a/docs/scripting/apis/prop.md
+++ b/docs/scripting/apis/prop.md
@@ -31,15 +31,6 @@ For Prop related events please see [Available Events - Prop Events](available-ev
 |----------------|--------------------------------------------------------------------------------|
 | void Destroy() | Destroys the prop; if called on the spawner's client, destroys it for everyone |
 
-## Example
+## Relevant Examples
 
-```csharp
-/// Destroys any prop that enters its trigger collider
-public partial class PropDestroyer : WasmBehaviour
-{
-    private void OnPropTriggerEnter(Prop prop, Collider other)
-    {
-        prop.Destroy();
-    }
-}
-```
+- [Destroy Prop on Contact](../examples/destroy-prop-on-contact.md)

--- a/docs/scripting/examples/.pages
+++ b/docs/scripting/examples/.pages
@@ -1,0 +1,7 @@
+﻿title: Examples
+nav:
+    - Destroy Prop On Contact: destroy-prop-on-contact.md
+    - Dropped Portals Follow Spawner: dropped-portals-follow-spawner.md
+    - Network Manager: network-manager.md
+    - Writing A Text File: writing-a-text-file.md
+    - Buffer Reader Writer Usage: buffer-reader-writer-usage.md

--- a/docs/scripting/examples/buffer-reader-writer-usage.md
+++ b/docs/scripting/examples/buffer-reader-writer-usage.md
@@ -1,0 +1,33 @@
+﻿# Example: BufferReaderWriter Usage
+
+Example demonstrating how to use the `BufferReaderWriter` utility to write and read various data types.
+
+```csharp
+public partial class BufferReaderWriterExample : WasmBehaviour
+{
+    private void Start()
+    {
+        // Write some values
+        BufferReaderWriter writer = new BufferReaderWriter();
+        writer.Write(12345);
+        writer.Write(3.14f);
+        writer.Write("Hello Buffer");
+        writer.Write(new int[] { 10, 20, 30 });
+
+        Debug.Log($"Wrote {writer.Length} bytes into buffer.");
+
+        // Read them back
+        BufferReaderWriter reader = new BufferReaderWriter(writer.Buffer[..writer.Length]);
+
+        reader.Read(out int intVal);
+        reader.Read(out float floatVal);
+        reader.Read(out string strVal);
+        reader.Read(out int[] arrayVal);
+
+        Debug.Log($"Int: {intVal}");
+        Debug.Log($"Float: {floatVal}");
+        Debug.Log($"String: {strVal}");
+        Debug.Log($"Array: [{string.Join(", ", arrayVal)}]");
+    }
+}
+```

--- a/docs/scripting/examples/destroy-prop-on-contact.md
+++ b/docs/scripting/examples/destroy-prop-on-contact.md
@@ -1,0 +1,14 @@
+﻿# Example: Destroy Prop on Contact
+
+Example using the [Prop API](../apis/prop.md) and [Prop Events](../apis/available-events.md/#prop-events) to destroy any prop that enters its trigger collider.
+
+```csharp
+// Destroys any prop that enters its trigger collider
+public partial class PropDestroyer : WasmBehaviour
+{
+    private void OnPropTriggerEnter(Prop prop, Collider other)
+    {
+        prop.Destroy();
+    }
+}
+```

--- a/docs/scripting/examples/dropped-portals-follow-spawner.md
+++ b/docs/scripting/examples/dropped-portals-follow-spawner.md
@@ -1,0 +1,31 @@
+﻿# Example: Dropped Portals Follow Spawner
+
+This example uses the [Portal API](../apis/portal.md) and [Portal Events](../apis/available-events.md/#portal-events) to make any portal dropped by a player follow them around.
+
+```csharp
+// Simple script that keeps portals within 2 meters of the player that spawned them
+public partial class PortalFollower : WasmBehaviour
+{
+    private readonly List<Portal> _spawnedPortals = new();
+    
+    private void OnPortalCreated(Portal portal) => _spawnedPortals.Add(portal);
+    private void OnPortalDestroyed(Portal portal) => _spawnedPortals.Remove(portal);
+
+    private void Update()
+    {
+        foreach (Portal portal in _spawnedPortals)
+        {
+            Player dropper = portal?.Spawner;
+            if (dropper == null) continue;
+            
+            Vector3 portalPos = portal.GetPosition();
+            Vector3 dropperPos = dropper.GameObject.transform.position;
+            if (Vector3.Distance(portalPos, dropperPos) > 2f)
+            {
+                Vector3 direction = (portalPos - dropperPos).normalized;
+                portal.SetPosition(dropperPos + direction * 2f);
+            }
+        }
+    }
+}
+```

--- a/docs/scripting/examples/network-manager.md
+++ b/docs/scripting/examples/network-manager.md
@@ -1,0 +1,44 @@
+﻿# Example: Network Manager
+
+Simple example of using the [Networking API](../apis/networking.md) and [Buffer Reader Writer](../apis/buffer-reader-writer.md) to send and receive chat messages.
+
+```csharp
+using CVR;
+using WasmScripting;
+
+public partial class NetworkManager : WasmBehaviour
+{
+
+    private void Awake()
+    {
+        Networking.OnReceiveMessage += OnNetworkMessageReceived;
+    }
+
+    private enum MessageType : byte
+    {
+        ChatMessage = 0,
+    }
+
+    private void OnNetworkMessageReceived(Player sender, Span<byte> message)
+    {
+        BufferReaderWriter reader = new(message);
+        reader.Read(out MessageType type);
+
+        switch (type)
+        {
+            case MessageType.ChatMessage:
+                reader.Read(out string chatText);
+                TextWall.Instance.AddGlobalUserText(sender, chatText);
+                break;
+        }
+    }
+
+    public void SendTextChatMessage(string text)
+    {
+        BufferReaderWriter writer = new();
+        writer.Write(MessageType.ChatMessage);
+        writer.Write(text);
+        Networking.SendMessage(writer);
+    }
+}
+```

--- a/docs/scripting/examples/writing-a-text-file.md
+++ b/docs/scripting/examples/writing-a-text-file.md
@@ -1,0 +1,33 @@
+﻿# Example: Writing a Text File
+
+Write and read a simple text file using the [File Storage API](../apis/file-storage.md) and [Buffer Reader Writer](../apis/buffer-reader-writer.md).
+
+```csharp
+using UnityEngine;
+using WasmScripting;
+using CVR;
+
+public partial class FileStorageExample : WasmBehaviour
+{
+    void Start()
+    {
+        // Write file
+        string dataToWrite = "Hello, FileStorage!";
+        byte[] bytesToWrite = System.Text.Encoding.UTF8.GetBytes(dataToWrite);
+        FileStorage.WriteFile("test", bytesToWrite);
+
+        // Read file
+        CVRFile file = FileStorage.ReadFile("test");
+
+        if (file.Length > 0)
+        {
+            string content = System.Text.Encoding.UTF8.GetString(file.Bytes);
+            Debug.Log($"Read from FileStorage: {content}");
+        }
+        else
+        {
+            Debug.Log("No data found in FileStorage for 'test'");
+        }
+    }
+}
+```

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -86,10 +86,13 @@ markdown_extensions:
   - pymdownx.superfences
   - pymdownx.tabbed:
       alternate_style: true
-  - pymdownx.inlinehilite
   - pymdownx.details
   - pymdownx.highlight:
       linenums: true
+      guess_lang: false
+      use_pygments: true
+      pygments_lang_class: true
+  - pymdownx.inlinehilite
   - pymdownx.emoji:
       emoji_index: !!python/name:material.extensions.emoji.twemoji
       emoji_generator: !!python/name:material.extensions.emoji.to_svg


### PR DESCRIPTION
- several tweaks and fixes to wasm docs pages after review
- moved examples from specific api reference pages to central place, linked relevant ones at bottom of reference pages
- added missing section for SendType in Network API
- fix for table border color only applying on one side